### PR TITLE
Add `repository`, `homepage` and `bugs` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.1.0",
   "type": "module",
   "description": "This prettier plugin format your gherkin (`.feature` files) documents.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mapado/prettier-plugin-gherkin.git"
+  }
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/mapado/prettier-plugin-gherkin.git"
   }
+  "bugs": {
+    "url": "https://github.com/mapado/prettier-plugin-gherkin/issues"
+  },
+  "homepage": "https://github.com/mapado/prettier-plugin-gherkin",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Thanks for your work on this prettier plugin.

This PR adds the `repository`, `homepage` and `bugs` field to the `package.json` so the source code and this GitHub repo can be found more easily. 
