### PR TITLE
default tab width should be 2 and not 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## Unreleased
+
+### Changed
+
+[BREAKING] Set default `tabWidth` to 2, as documented in [Gherkin Reference](https://cucumber.io/docs/gherkin/reference/).
+
+If you want to use four space, you can override this values in your prettier configuration file:
+
+```json
+{
+  // …
+  "overrides": [
+    {
+      "files": "*.feature",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
+}
+```
+
 ## [2.4.1] - 2024-07-26
 
 - Re-set hardline for Background [#27](https://github.com/mapado/prettier-plugin-gherkin/pull/27) by [@jdeniau](https://github.com/jdeniau)

--- a/src/index.ts
+++ b/src/index.ts
@@ -706,7 +706,7 @@ const plugin: Plugin<TypedGherkinNode<GherkinNode>> = {
   },
   defaultOptions: {
     printWidth: 120,
-    tabWidth: 4,
+    tabWidth: 2,
   },
   options: {
     escapeBackslashes: {

--- a/tests/good/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/good/__snapshots__/jsfmt.spec.mjs.snap
@@ -20,6 +20,22 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Background
 
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Background
+
     Background: a simple background
         Given the minimalism inside a background
 
@@ -36,14 +52,14 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Background
 
-    Background: a simple background
-        Given the minimalism inside a background
+  Background: a simple background
+    Given the minimalism inside a background
 
-    Scenario: minimalistic
-        Given the minimalism
+  Scenario: minimalistic
+    Given the minimalism
 
-    Scenario: also minimalistic
-        Given the minimalism
+  Scenario: also minimalistic
+    Given the minimalism
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -81,6 +97,36 @@ Feature: Complex background
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+        | value |
+        | 1     |
+        | 2     |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Complex background
     We want to ensure PickleStep all have different IDs
 
     Background: a simple background
@@ -111,29 +157,29 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Complex background
-    We want to ensure PickleStep all have different IDs
+  We want to ensure PickleStep all have different IDs
 
-    Background: a simple background
-        Given the minimalism inside a background
+  Background: a simple background
+    Given the minimalism inside a background
 
-    Scenario: minimalistic
-        Given the minimalism
+  Scenario: minimalistic
+    Given the minimalism
 
-    Scenario: also minimalistic
-        Given the minimalism
+  Scenario: also minimalistic
+    Given the minimalism
 
-    Rule: My Rule
+  Rule: My Rule
 
-        Background:
-            Given a rule background step
+    Background:
+      Given a rule background step
 
-        Scenario: with examples
-            Given the <value> minimalism
+    Scenario: with examples
+      Given the <value> minimalism
 
-            Examples:
-                | value |
-                | 1     |
-                | 2     |
+      Examples:
+        | value |
+        | 1     |
+        | 2     |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -166,6 +212,29 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: DataTables
 
+  Scenario: minimalistic
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: DataTables
+
     Scenario: minimalistic
         Given a simple data table
             | foo | bar |
@@ -189,21 +258,21 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: DataTables
 
-    Scenario: minimalistic
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
+  Scenario: minimalistic
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -225,6 +294,19 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: DataTables
 
+  Scenario: some whitespace is important
+    Given 3 lines of poetry on 5 lines
+      | \\nraindrops--\\nher last kiss\\ngoodbye.\\r\\n |
+    Given an example of negative space
+      | lost        i n        space |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: DataTables
+
     Scenario: some whitespace is important
         Given 3 lines of poetry on 5 lines
             | \\nraindrops--\\nher last kiss\\ngoodbye.\\r\\n |
@@ -238,12 +320,12 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: DataTables
 
-    Scenario: some whitespace is important
-        Given 3 lines of poetry on 5 lines
-            | \\nraindrops--\\nher last kiss\\ngoodbye.\\r\\n |
+  Scenario: some whitespace is important
+    Given 3 lines of poetry on 5 lines
+      | \\nraindrops--\\nher last kiss\\ngoodbye.\\r\\n |
 
-        Given an example of negative space
-            | lost        i n        space |
+    Given an example of negative space
+      | lost        i n        space |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -309,6 +391,68 @@ This is an examples description
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Descriptions everywhere
+  This is a single line description
+
+  Scenario: two lines
+    This description
+    has two lines and indented with two spaces
+
+    Given the minimalism
+
+  Scenario: without indentation
+    This is a description without indentation
+
+    Given the minimalism
+
+  Scenario: empty lines in the middle
+    This description
+
+    has an empty line in the middle
+
+    Given the minimalism
+
+  Scenario: empty lines around
+    This description
+    has an empty lines around
+
+    Given the minimalism
+
+  Scenario: comment after description
+    This description
+    has a comment after
+
+    # this is a comment
+    Given the minimalism
+
+  Scenario: comment right after description
+    This description
+    has a comment right after
+
+    #  this is another comment
+    Given the minimalism
+
+  Scenario: description with escaped docstring separator
+    This description has an \\"\\"\\" (escaped docstring sparator)
+
+    Given the minimalism
+
+  Scenario Outline: scenario outline with a description
+    This is a scenario outline description
+
+    Given the minimalism
+
+    Examples: examples with description
+      This is an examples description
+
+      | foo |
+      | bar |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Descriptions everywhere
     This is a single line description
 
     Scenario: two lines
@@ -371,61 +515,61 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Descriptions everywhere
-    This is a single line description
+  This is a single line description
 
-    Scenario: two lines
-        This description
-        has two lines and indented with two spaces
+  Scenario: two lines
+    This description
+    has two lines and indented with two spaces
 
-        Given the minimalism
+    Given the minimalism
 
-    Scenario: without indentation
-        This is a description without indentation
+  Scenario: without indentation
+    This is a description without indentation
 
-        Given the minimalism
+    Given the minimalism
 
-    Scenario: empty lines in the middle
-        This description
+  Scenario: empty lines in the middle
+    This description
 
-        has an empty line in the middle
+    has an empty line in the middle
 
-        Given the minimalism
+    Given the minimalism
 
-    Scenario: empty lines around
-        This description
-        has an empty lines around
+  Scenario: empty lines around
+    This description
+    has an empty lines around
 
-        Given the minimalism
+    Given the minimalism
 
-    Scenario: comment after description
-        This description
-        has a comment after
+  Scenario: comment after description
+    This description
+    has a comment after
 
-        # this is a comment
-        Given the minimalism
+    # this is a comment
+    Given the minimalism
 
-    Scenario: comment right after description
-        This description
-        has a comment right after
+  Scenario: comment right after description
+    This description
+    has a comment right after
 
-        #  this is another comment
-        Given the minimalism
+    #  this is another comment
+    Given the minimalism
 
-    Scenario: description with escaped docstring separator
-        This description has an \\"\\"\\" (escaped docstring sparator)
+  Scenario: description with escaped docstring separator
+    This description has an \\"\\"\\" (escaped docstring sparator)
 
-        Given the minimalism
+    Given the minimalism
 
-    Scenario Outline: scenario outline with a description
-        This is a scenario outline description
+  Scenario Outline: scenario outline with a description
+    This is a scenario outline description
 
-        Given the minimalism
+    Given the minimalism
 
-        Examples: examples with description
-            This is an examples description
+    Examples: examples with description
+      This is an examples description
 
-            | foo |
-            | bar |
+      | foo |
+      | bar |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -488,6 +632,61 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: DocString variations
 
+  Scenario: minimalistic
+    Given a simple DocString
+      """
+      first line (no indent)
+        second line (indented with two spaces)
+
+      third line was empty
+      """
+    Given a DocString with content type
+      """xml
+      <foo>
+        <bar />
+      </foo>
+      """
+    And a DocString with wrong indentation
+      """
+      wrongly indented line
+      """
+    And a DocString with alternative separator
+      \`\`\`
+      first line
+      second line
+      \`\`\`
+    And a DocString with normal separator inside
+      \`\`\`
+      first line
+      """
+      third line
+      \`\`\`
+    And a DocString with alternative separator inside
+      """
+      first line
+      \`\`\`
+      third line
+      """
+    And a DocString with escaped separator inside
+      """
+      first line
+      \\"\\"\\"
+      third line
+      """
+    And a DocString with an escaped alternative separator inside
+      \`\`\`
+      first line
+      \\\`\\\`\\\`
+      third line
+      \`\`\`
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: DocString variations
+
     Scenario: minimalistic
         Given a simple DocString
             """
@@ -543,54 +742,54 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: DocString variations
 
-    Scenario: minimalistic
-        Given a simple DocString
-            """
-            first line (no indent)
-              second line (indented with two spaces)
+  Scenario: minimalistic
+    Given a simple DocString
+      """
+      first line (no indent)
+        second line (indented with two spaces)
 
-            third line was empty
-            """
+      third line was empty
+      """
 
-        Given a DocString with content type
-            """xml
-            <foo>
-                <bar />
-            </foo>
-            """
-        And a DocString with wrong indentation
-            """
-            wrongly indented line
-            """
-        And a DocString with alternative separator
-            \`\`\`
-            first line
-            second line
-            \`\`\`
-        And a DocString with normal separator inside
-            \`\`\`
-            first line
-            """
-            third line
-            \`\`\`
-        And a DocString with alternative separator inside
-            """
-            first line
-            \`\`\`
-            third line
-            """
-        And a DocString with escaped separator inside
-            """
-            first line
-            \\"\\"\\"
-            third line
-            """
-        And a DocString with an escaped alternative separator inside
-            \`\`\`
-            first line
-            \\\`\\\`\\\`
-            third line
-            \`\`\`
+    Given a DocString with content type
+      """xml
+      <foo>
+        <bar />
+      </foo>
+      """
+    And a DocString with wrong indentation
+      """
+      wrongly indented line
+      """
+    And a DocString with alternative separator
+      \`\`\`
+      first line
+      second line
+      \`\`\`
+    And a DocString with normal separator inside
+      \`\`\`
+      first line
+      """
+      third line
+      \`\`\`
+    And a DocString with alternative separator inside
+      """
+      first line
+      \`\`\`
+      third line
+      """
+    And a DocString with escaped separator inside
+      """
+      first line
+      \\"\\"\\"
+      third line
+      """
+    And a DocString with an escaped alternative separator inside
+      \`\`\`
+      first line
+      \\\`\\\`\\\`
+      third line
+      \`\`\`
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -602,6 +801,12 @@ source
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 options: {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -633,6 +838,23 @@ Feature: Escaped pipes
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Escaped pipes
+  The \\-character will be considered as an escape in table cell
+  iff it is followed by a |-character, a \\-character or an n.
+
+  Scenario: They are the future
+    Given they have arrived
+      | æ | o |
+      | a | ø |
+    Given they have arrived
+      | \\|æ\\\\n     | \\o\\no\\  |
+      | \\\\\\|a\\\\\\\\n | ø\\\\\\nø\\ |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Escaped pipes
     The \\-character will be considered as an escape in table cell
     iff it is followed by a |-character, a \\-character or an n.
 
@@ -650,17 +872,17 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Escaped pipes
-    The \\-character will be considered as an escape in table cell
-    iff it is followed by a |-character, a \\-character or an n.
+  The \\-character will be considered as an escape in table cell
+  iff it is followed by a |-character, a \\-character or an n.
 
-    Scenario: They are the future
-        Given they have arrived
-            | æ | o |
-            | a | ø |
+  Scenario: They are the future
+    Given they have arrived
+      | æ | o |
+      | a | ø |
 
-        Given they have arrived
-            | \\|æ\\\\n     | \\o\\no\\  |
-            | \\\\\\|a\\\\\\\\n | ø\\\\\\nø\\ |
+    Given they have arrived
+      | \\|æ\\\\n     | \\o\\no\\  |
+      | \\\\\\|a\\\\\\\\n | ø\\\\\\nø\\ |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -683,6 +905,20 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Example token used multiple times
 
+  Scenario Outline: Token used twice in a single step
+    Given <what> <what>
+
+    Examples:
+      | what  |
+      | usage |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Example token used multiple times
+
     Scenario Outline: Token used twice in a single step
         Given <what> <what>
 
@@ -697,12 +933,12 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Example token used multiple times
 
-    Scenario Outline: Token used twice in a single step
-        Given <what> <what>
+  Scenario Outline: Token used twice in a single step
+    Given <what> <what>
 
-        Examples:
-            | what  |
-            | usage |
+    Examples:
+      | what  |
+      | usage |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -731,6 +967,26 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Example tokens everywhere
 
+  Scenario Outline: the <one>
+    Given the <two>:
+      """
+      <three>
+      """
+    Given the <four>:
+      | <five> |
+
+    Examples:
+      | one | two  | three | four   | five  |
+      | un  | deux | trois | quatre | cinq  |
+      | uno | dos  | tres  | quatro | cinco |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Example tokens everywhere
+
     Scenario Outline: the <one>
         Given the <two>:
             """
@@ -751,19 +1007,19 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Example tokens everywhere
 
-    Scenario Outline: the <one>
-        Given the <two>:
-            """
-            <three>
-            """
+  Scenario Outline: the <one>
+    Given the <two>:
+      """
+      <three>
+      """
 
-        Given the <four>:
-            | <five> |
+    Given the <four>:
+      | <five> |
 
-        Examples:
-            | one | two  | three | four   | five  |
-            | un  | deux | trois | quatre | cinq  |
-            | uno | dos  | tres  | quatro | cinco |
+    Examples:
+      | one | two  | three | four   | five  |
+      | un  | deux | trois | quatre | cinq  |
+      | uno | dos  | tres  | quatro | cinco |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -784,6 +1040,17 @@ options: {}
 # language: em
 📚: 🙈🙉🙊
 
+  📕: 💃
+    😐🎸
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# language: em
+📚: 🙈🙉🙊
+
     📕: 💃
         😐🎸
 
@@ -795,8 +1062,8 @@ options: {
 # language: em
 📚: 🙈🙉🙊
 
-    📕: 💃
-        😐🎸
+  📕: 💃
+    😐🎸
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -875,6 +1142,75 @@ options: {}
 # language: fr
 Fonctionnalité: i18n support
 
+  Scénario: Support des caractères spéciaux
+    Soit un exemple de scénario en français
+    Quand j'ai 1 gâteau
+    Alors je suis heureux
+
+  Scénario: Support du mot-clef "Etant donné que "
+    Etant donné que j'aime les gâteaux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
+
+  Scénario: Support du mot-clef "Etant donné qu'"
+    Etant donné qu'offrir un gâteau rend heureux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
+
+  Scénario: Support du mot-clef "Étant donné que "
+    Étant donné que j'aime les gâteaux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
+
+  Scénario: Support du mot-clef "Étant donné qu'"
+    Étant donné qu'offrir un gâteau rend heureux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
+
+  Scénario: Support du mot-clef "Et que "
+    Soit un exemple de scénario en français
+    Lorsque j'ai 2 gâteaux
+    Et que quelqu'un m'offre 1 gâteau
+    Alors j'ai 3 gâteaux
+
+  Scénario: Support du mot-clef "Et qu'"
+    Soit un exemple de scénario en français
+    Lorsque j'ai 2 gâteaux
+    Et qu'on m'offre 1 gâteau
+    Alors j'ai 3 gâteaux
+
+  Scénario: Support du mot-clef "Et "
+    Soit un exemple de scénario en français
+    Quand j'ai 2 gâteaux
+    Et quelqu'un m'offre 1 gâteau
+    Alors j'ai 3 gâteaux
+
+  Scénario: Support du mot-clef "Mais que "
+    Soit un exemple de scénario en français
+    Lorsque j'ai 2 gâteaux
+    Mais que quelqu'un me vole 1 gâteau
+    Alors j'ai 1 gâteau
+
+  Scénario: Support du mot-clef "Mais qu'"
+    Soit un exemple de scénario en français
+    Lorsque j'ai 2 gâteaux
+    Mais qu'on me vole 1 gâteau
+    Alors j'ai 1 gâteau
+
+  Scénario: Support du mot-clef "Mais "
+    Soit un exemple de scénario en français
+    Quand j'ai 2 gâteaux
+    Mais quelqu'un me vole 1 gâteau
+    Alors j'ai 1 gâteau
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# language: fr
+Fonctionnalité: i18n support
+
     Scénario: Support des caractères spéciaux
         Soit un exemple de scénario en français
         Quand j'ai 1 gâteau
@@ -944,77 +1280,77 @@ options: {
 # language: fr
 Fonctionnalité: i18n support
 
-    Scénario: Support des caractères spéciaux
-        Soit un exemple de scénario en français
+  Scénario: Support des caractères spéciaux
+    Soit un exemple de scénario en français
 
-        Quand j'ai 1 gâteau
-        Alors je suis heureux
+    Quand j'ai 1 gâteau
+    Alors je suis heureux
 
-    Scénario: Support du mot-clef "Etant donné que "
-        Etant donné que j'aime les gâteaux
+  Scénario: Support du mot-clef "Etant donné que "
+    Etant donné que j'aime les gâteaux
 
-        Lorsqu'on m'offre 1 gâteau
-        Alors je suis heureux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
 
-    Scénario: Support du mot-clef "Etant donné qu'"
-        Etant donné qu'offrir un gâteau rend heureux
+  Scénario: Support du mot-clef "Etant donné qu'"
+    Etant donné qu'offrir un gâteau rend heureux
 
-        Lorsqu'on m'offre 1 gâteau
-        Alors je suis heureux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
 
-    Scénario: Support du mot-clef "Étant donné que "
-        Étant donné que j'aime les gâteaux
+  Scénario: Support du mot-clef "Étant donné que "
+    Étant donné que j'aime les gâteaux
 
-        Lorsqu'on m'offre 1 gâteau
-        Alors je suis heureux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
 
-    Scénario: Support du mot-clef "Étant donné qu'"
-        Étant donné qu'offrir un gâteau rend heureux
+  Scénario: Support du mot-clef "Étant donné qu'"
+    Étant donné qu'offrir un gâteau rend heureux
 
-        Lorsqu'on m'offre 1 gâteau
-        Alors je suis heureux
+    Lorsqu'on m'offre 1 gâteau
+    Alors je suis heureux
 
-    Scénario: Support du mot-clef "Et que "
-        Soit un exemple de scénario en français
+  Scénario: Support du mot-clef "Et que "
+    Soit un exemple de scénario en français
 
-        Lorsque j'ai 2 gâteaux
-        Et que quelqu'un m'offre 1 gâteau
-        Alors j'ai 3 gâteaux
+    Lorsque j'ai 2 gâteaux
+    Et que quelqu'un m'offre 1 gâteau
+    Alors j'ai 3 gâteaux
 
-    Scénario: Support du mot-clef "Et qu'"
-        Soit un exemple de scénario en français
+  Scénario: Support du mot-clef "Et qu'"
+    Soit un exemple de scénario en français
 
-        Lorsque j'ai 2 gâteaux
-        Et qu'on m'offre 1 gâteau
-        Alors j'ai 3 gâteaux
+    Lorsque j'ai 2 gâteaux
+    Et qu'on m'offre 1 gâteau
+    Alors j'ai 3 gâteaux
 
-    Scénario: Support du mot-clef "Et "
-        Soit un exemple de scénario en français
+  Scénario: Support du mot-clef "Et "
+    Soit un exemple de scénario en français
 
-        Quand j'ai 2 gâteaux
-        Et quelqu'un m'offre 1 gâteau
-        Alors j'ai 3 gâteaux
+    Quand j'ai 2 gâteaux
+    Et quelqu'un m'offre 1 gâteau
+    Alors j'ai 3 gâteaux
 
-    Scénario: Support du mot-clef "Mais que "
-        Soit un exemple de scénario en français
+  Scénario: Support du mot-clef "Mais que "
+    Soit un exemple de scénario en français
 
-        Lorsque j'ai 2 gâteaux
-        Mais que quelqu'un me vole 1 gâteau
-        Alors j'ai 1 gâteau
+    Lorsque j'ai 2 gâteaux
+    Mais que quelqu'un me vole 1 gâteau
+    Alors j'ai 1 gâteau
 
-    Scénario: Support du mot-clef "Mais qu'"
-        Soit un exemple de scénario en français
+  Scénario: Support du mot-clef "Mais qu'"
+    Soit un exemple de scénario en français
 
-        Lorsque j'ai 2 gâteaux
-        Mais qu'on me vole 1 gâteau
-        Alors j'ai 1 gâteau
+    Lorsque j'ai 2 gâteaux
+    Mais qu'on me vole 1 gâteau
+    Alors j'ai 1 gâteau
 
-    Scénario: Support du mot-clef "Mais "
-        Soit un exemple de scénario en français
+  Scénario: Support du mot-clef "Mais "
+    Soit un exemple de scénario en français
 
-        Quand j'ai 2 gâteaux
-        Mais quelqu'un me vole 1 gâteau
-        Alors j'ai 1 gâteau
+    Quand j'ai 2 gâteaux
+    Mais quelqu'un me vole 1 gâteau
+    Alors j'ai 1 gâteau
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1037,6 +1373,19 @@ options: {}
 # language: no
 Egenskap: i18n support
 
+  Scenario: Parsing many languages
+    Gitt Gherkin supports many languages
+    Når Norwegian keywords are parsed
+    Så they should be recognized
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# language: no
+Egenskap: i18n support
+
     Scenario: Parsing many languages
         Gitt Gherkin supports many languages
         Når Norwegian keywords are parsed
@@ -1050,11 +1399,11 @@ options: {
 # language: no
 Egenskap: i18n support
 
-    Scenario: Parsing many languages
-        Gitt Gherkin supports many languages
+  Scenario: Parsing many languages
+    Gitt Gherkin supports many languages
 
-        Når Norwegian keywords are parsed
-        Så they should be recognized
+    Når Norwegian keywords are parsed
+    Så they should be recognized
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1075,6 +1424,18 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete backgrounds, Part 1
 
+  Background: no steps
+
+  Scenario: still pickles up
+    * a step
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Incomplete backgrounds, Part 1
+
     Background: no steps
 
     Scenario: still pickles up
@@ -1087,10 +1448,10 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete backgrounds, Part 1
 
-    Background: no steps
+  Background: no steps
 
-    Scenario: still pickles up
-        * a step
+  Scenario: still pickles up
+    * a step
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1112,6 +1473,21 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete backgrounds, Part 2
 
+  Background: just a description
+    A short description
+
+
+
+  Scenario: still pickles up
+    * a step
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Incomplete backgrounds, Part 2
+
     Background: just a description
         A short description
 
@@ -1127,13 +1503,13 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete backgrounds, Part 2
 
-    Background: just a description
-        A short description
+  Background: just a description
+    A short description
 
 
 
-    Scenario: still pickles up
-        * a step
+  Scenario: still pickles up
+    * a step
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1149,6 +1525,16 @@ Feature: Just a description
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Just a description
+  A short description
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Just a description
     A short description
 
 
@@ -1159,7 +1545,7 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Just a description
-    A short description
+  A short description
 
 
 
@@ -1174,6 +1560,15 @@ Feature: Empty feature
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 options: {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Empty feature
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Empty feature
 
@@ -1203,6 +1598,13 @@ options: {}
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Just a comment
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
  "forceNewlineBetweenStepBlocks": true
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1227,6 +1629,19 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete scenarios
 
+  Background: Adding a background won't make a pickle
+    * a step
+
+  Scenario: no steps
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Incomplete scenarios
+
     Background: Adding a background won't make a pickle
         * a step
 
@@ -1240,10 +1655,10 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete scenarios
 
-    Background: Adding a background won't make a pickle
-        * a step
+  Background: Adding a background won't make a pickle
+    * a step
 
-    Scenario: no steps
+  Scenario: no steps
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1283,6 +1698,35 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete scenario outlines
 
+  Background: Adding a background won't make a pickle
+    * a step
+
+  Scenario Outline: steps, no examples
+    Given a step
+
+  Scenario Outline: no steps, no examples
+
+
+  Scenario Outline: no steps, no table
+    Examples:
+
+
+  Scenario Outline: no steps, only table header
+    Examples:
+      | what |
+
+  Scenario Outline: no steps, one example header
+    Examples:
+      | nope |
+      | nada |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Incomplete scenario outlines
+
     Background: Adding a background won't make a pickle
         * a step
 
@@ -1312,27 +1756,27 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Incomplete scenario outlines
 
-    Background: Adding a background won't make a pickle
-        * a step
+  Background: Adding a background won't make a pickle
+    * a step
 
-    Scenario Outline: steps, no examples
-        Given a step
+  Scenario Outline: steps, no examples
+    Given a step
 
-    Scenario Outline: no steps, no examples
-
-
-    Scenario Outline: no steps, no table
-        Examples:
+  Scenario Outline: no steps, no examples
 
 
-    Scenario Outline: no steps, only table header
-        Examples:
-            | what |
+  Scenario Outline: no steps, no table
+    Examples:
 
-    Scenario Outline: no steps, one example header
-        Examples:
-            | nope |
-            | nada |
+
+  Scenario Outline: no steps, only table header
+    Examples:
+      | what |
+
+  Scenario Outline: no steps, one example header
+    Examples:
+      | nope |
+      | nada |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1354,6 +1798,17 @@ options: {}
 # language: en
 Feature: Explicit language specification
 
+  Scenario: minimalistic
+    Given the minimalism
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# language: en
+Feature: Explicit language specification
+
     Scenario: minimalistic
         Given the minimalism
 
@@ -1365,8 +1820,8 @@ options: {
 # language: en
 Feature: Explicit language specification
 
-    Scenario: minimalistic
-        Given the minimalism
+  Scenario: minimalistic
+    Given the minimalism
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1384,6 +1839,16 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal
 
+  Scenario: minimalistic
+    Given the minimalism
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Minimal
+
     Scenario: minimalistic
         Given the minimalism
 
@@ -1394,8 +1859,8 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal
 
-    Scenario: minimalistic
-        Given the minimalism
+  Scenario: minimalistic
+    Given the minimalism
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1414,6 +1879,16 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal
 
+  Example: minimalistic
+    Given the minimalism
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Minimal
+
     Example: minimalistic
         Given the minimalism
 
@@ -1424,8 +1899,8 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal
 
-    Example: minimalistic
-        Given the minimalism
+  Example: minimalistic
+    Given the minimalism
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1458,6 +1933,29 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: test
 
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football | 69       |
+      | pool     | 5.6      |
+
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with \`ruby -e 'STDOUT.write "\\u00A0\\u0020\\u0009".encode("utf-8")' | pbcopy\`
+    # and pasted.
+    Examples:
+      | color |
+      | red   |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: test
+
     Scenario: test
         Given a <color> ball with:
             | type     | diameter |
@@ -1481,21 +1979,21 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: test
 
-    Scenario: test
-        Given a <color> ball with:
-            | type     | diameter |
-            | football | 69       |
-            | pool     | 5.6      |
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football | 69       |
+      | pool     | 5.6      |
 
-        # The "red" cell below has the following whitespace characters on each side:
-        # - U+00A0 (non-breaking space)
-        # - U+0020 (space)
-        # - U+0009 (tab)
-        # This is generated with \`ruby -e 'STDOUT.write "\\u00A0\\u0020\\u0009".encode("utf-8")' | pbcopy\`
-        # and pasted.
-        Examples:
-            | color |
-            | red   |
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with \`ruby -e 'STDOUT.write "\\u00A0\\u0020\\u0009".encode("utf-8")' | pbcopy\`
+    # and pasted.
+    Examples:
+      | color |
+      | red   |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1529,6 +2027,33 @@ options: {}
 @a
 Feature:
 
+  @b
+  @c
+  Scenario Outline:
+    Given <x>
+
+    Examples:
+      | x |
+      | y |
+
+  @d
+  @e
+  Scenario Outline:
+    Given <m>
+
+    @f
+    Examples:
+      | m |
+      | n |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@a
+Feature:
+
     @b
     @c
     Scenario Outline:
@@ -1556,24 +2081,24 @@ options: {
 @a
 Feature:
 
-    @b
-    @c
-    Scenario Outline:
-        Given <x>
+  @b
+  @c
+  Scenario Outline:
+    Given <x>
 
-        Examples:
-            | x |
-            | y |
+    Examples:
+      | x |
+      | y |
 
-    @d
-    @e
-    Scenario Outline:
-        Given <m>
+  @d
+  @e
+  Scenario Outline:
+    Given <m>
 
-        @f
-        Examples:
-            | m |
-            | n |
+    @f
+    Examples:
+      | m |
+      | n |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1606,6 +2131,31 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Some rules
 
+  Background:
+    Given fb
+
+  Rule: A
+    The rule A description
+
+    Background:
+      Given ab
+
+    Example: Example A
+      Given a
+
+  Rule: B
+    The rule B description
+
+    Example: Example B
+      Given b
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Some rules
+
     Background:
         Given fb
 
@@ -1631,23 +2181,23 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Some rules
 
+  Background:
+    Given fb
+
+  Rule: A
+    The rule A description
+
     Background:
-        Given fb
+      Given ab
 
-    Rule: A
-        The rule A description
+    Example: Example A
+      Given a
 
-        Background:
-            Given ab
+  Rule: B
+    The rule B description
 
-        Example: Example A
-            Given a
-
-    Rule: B
-        The rule B description
-
-        Example: Example B
-            Given b
+    Example: Example B
+      Given b
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1691,6 +2241,40 @@ options: {}
 @tag_feature
 Feature: Some tagged rules
 
+  Rule: Untagged rule
+    The untagged rule description
+
+    Scenario: Scenario with only a feature tag
+      Given a
+
+  @tag_rule
+  Rule: Tagged rule
+    The tagged rule description
+
+    Scenario: Scenario with feature and rule tags
+      Given b
+
+    @tag_scenario
+    Scenario: Scenario with feature, rule and scenario tags
+      Given b
+
+    @tag_outline
+    Scenario Outline: Tagged Scenario outline
+      Given b
+
+      @examples_tag
+      Examples:
+        | header |
+        | a      |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@tag_feature
+Feature: Some tagged rules
+
     Rule: Untagged rule
         The untagged rule description
 
@@ -1725,31 +2309,31 @@ options: {
 @tag_feature
 Feature: Some tagged rules
 
-    Rule: Untagged rule
-        The untagged rule description
+  Rule: Untagged rule
+    The untagged rule description
 
-        Scenario: Scenario with only a feature tag
-            Given a
+    Scenario: Scenario with only a feature tag
+      Given a
 
-    @tag_rule
-    Rule: Tagged rule
-        The tagged rule description
+  @tag_rule
+  Rule: Tagged rule
+    The tagged rule description
 
-        Scenario: Scenario with feature and rule tags
-            Given b
+    Scenario: Scenario with feature and rule tags
+      Given b
 
-        @tag_scenario
-        Scenario: Scenario with feature, rule and scenario tags
-            Given b
+    @tag_scenario
+    Scenario: Scenario with feature, rule and scenario tags
+      Given b
 
-        @tag_outline
-        Scenario Outline: Tagged Scenario outline
-            Given b
+    @tag_outline
+    Scenario Outline: Tagged Scenario outline
+      Given b
 
-            @examples_tag
-            Examples:
-                | header |
-                | a      |
+      @examples_tag
+      Examples:
+        | header |
+        | a      |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1769,6 +2353,18 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature:
 
+  Rule:
+
+    Scenario:
+      Given text
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature:
+
     Rule:
 
         Scenario:
@@ -1781,10 +2377,10 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature:
 
-    Rule:
+  Rule:
 
-        Scenario:
-            Given text
+    Scenario:
+      Given text
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1807,6 +2403,20 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal Scenario Outline
 
+  Scenario: minimalistic
+    Given the <what>
+
+    Examples:
+      | what       |
+      | minimalism |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Minimal Scenario Outline
+
     Scenario: minimalistic
         Given the <what>
 
@@ -1821,12 +2431,12 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal Scenario Outline
 
-    Scenario: minimalistic
-        Given the <what>
+  Scenario: minimalistic
+    Given the <what>
 
-        Examples:
-            | what       |
-            | minimalism |
+    Examples:
+      | what       |
+      | minimalism |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1848,6 +2458,20 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal Scenario Outline
 
+  Scenario Outline: minimalistic
+    Given the <what>
+
+    Examples:
+      | what       |
+      | minimalism |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Minimal Scenario Outline
+
     Scenario Outline: minimalistic
         Given the <what>
 
@@ -1862,12 +2486,12 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Minimal Scenario Outline
 
-    Scenario Outline: minimalistic
-        Given the <what>
+  Scenario Outline: minimalistic
+    Given the <what>
 
-        Examples:
-            | what       |
-            | minimalism |
+    Examples:
+      | what       |
+      | minimalism |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1894,6 +2518,24 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Scenario Outline with a docstring
 
+  Scenario Outline: Greetings come in many forms
+    Given this file:
+      """<type>
+      Greeting:<content>
+      """
+
+    Examples:
+      | type | content |
+      | en   | Hello   |
+      | fr   | Bonjour |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Scenario Outline with a docstring
+
     Scenario Outline: Greetings come in many forms
         Given this file:
             """<type>
@@ -1912,16 +2554,16 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Scenario Outline with a docstring
 
-    Scenario Outline: Greetings come in many forms
-        Given this file:
-            """<type>
-            Greeting:<content>
-            """
+  Scenario Outline: Greetings come in many forms
+    Given this file:
+      """<type>
+      Greeting:<content>
+      """
 
-        Examples:
-            | type | content |
-            | en   | Hello   |
-            | fr   | Bonjour |
+    Examples:
+      | type | content |
+      | en   | Hello   |
+      | fr   | Bonjour |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1944,6 +2586,20 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Scenario Outline with a value with a dollar sign ($)
 
+  Scenario Outline: minimalistic
+    Given the <what>
+
+    Examples:
+      | what     |
+      | pa$$word |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Scenario Outline with a value with a dollar sign ($)
+
     Scenario Outline: minimalistic
         Given the <what>
 
@@ -1958,12 +2614,12 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Scenario Outline with a value with a dollar sign ($)
 
-    Scenario Outline: minimalistic
-        Given the <what>
+  Scenario Outline: minimalistic
+    Given the <what>
 
-        Examples:
-            | what     |
-            | pa$$word |
+    Examples:
+      | what     |
+      | pa$$word |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -1987,6 +2643,22 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Scenario Outline with values with trailing backslash
 
+  Scenario Outline: minimalistic
+    Given <what>
+    When <this>
+    Then <that>
+
+    Examples:
+      | what | this  | that  |
+      | x\\y  | this\\ | that\\ |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Scenario Outline with values with trailing backslash
+
     Scenario Outline: minimalistic
         Given <what>
         When <this>
@@ -2003,15 +2675,15 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Scenario Outline with values with trailing backslash
 
-    Scenario Outline: minimalistic
-        Given <what>
+  Scenario Outline: minimalistic
+    Given <what>
 
-        When <this>
-        Then <that>
+    When <this>
+    Then <that>
 
-        Examples:
-            | what | this  | that  |
-            | x\\y  | this\\ | that\\ |
+    Examples:
+      | what | this  | that  |
+      | x\\y  | this\\ | that\\ |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -2045,6 +2717,33 @@ options: {}
 @a
 Feature:
 
+  @b
+  @c
+  Scenario Outline:
+    Given <x>
+
+    Examples:
+      | x |
+      | y |
+
+  @d
+  @e
+  Scenario Outline:
+    Given <m>
+
+    @f
+    Examples:
+      | m |
+      | n |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@a
+Feature:
+
     @b
     @c
     Scenario Outline:
@@ -2072,24 +2771,24 @@ options: {
 @a
 Feature:
 
-    @b
-    @c
-    Scenario Outline:
-        Given <x>
+  @b
+  @c
+  Scenario Outline:
+    Given <x>
 
-        Examples:
-            | x |
-            | y |
+    Examples:
+      | x |
+      | y |
 
-    @d
-    @e
-    Scenario Outline:
-        Given <m>
+  @d
+  @e
+  Scenario Outline:
+    Given <m>
 
-        @f
-        Examples:
-            | m |
-            | n |
+    @f
+    Examples:
+      | m |
+      | n |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -2121,6 +2820,30 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Tagged Examples
 
+  Scenario Outline: minimalistic
+    Given the <what>
+
+    @foo
+    Examples:
+      | what |
+      | foo  |
+
+    @bar
+    Examples:
+      | what |
+      | bar  |
+
+  @zap
+  Scenario: ha ok
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Tagged Examples
+
     Scenario Outline: minimalistic
         Given the <what>
 
@@ -2145,21 +2868,21 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Tagged Examples
 
-    Scenario Outline: minimalistic
-        Given the <what>
+  Scenario Outline: minimalistic
+    Given the <what>
 
-        @foo
-        Examples:
-            | what |
-            | foo  |
+    @foo
+    Examples:
+      | what |
+      | foo  |
 
-        @bar
-        Examples:
-            | what |
-            | bar  |
+    @bar
+    Examples:
+      | what |
+      | bar  |
 
-    @zap
-    Scenario: ha ok
+  @zap
+  Scenario: ha ok
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2174,6 +2897,16 @@ OH HAI: STUFFING
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 options: {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# language: en-lol
+OH HAI: STUFFING
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # language: en-lol
 OH HAI: STUFFING
@@ -2214,6 +2947,22 @@ options: {}
 @sometag
 Feature: Foo
 
+  Scenario Outline: Bar
+    Then Baz
+
+    Examples:
+      | name |
+      | X    |
+      | Y    |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@sometag
+Feature: Foo
+
     Scenario Outline: Bar
         Then Baz
 
@@ -2230,13 +2979,13 @@ options: {
 @sometag
 Feature: Foo
 
-    Scenario Outline: Bar
-        Then Baz
+  Scenario Outline: Bar
+    Then Baz
 
-        Examples:
-            | name |
-            | X    |
-            | Y    |
+    Examples:
+      | name |
+      | X    |
+      | Y    |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -2294,6 +3043,58 @@ options: {}
 @feature_tag3
 Feature: Minimal Scenario Outline
 
+  @scenario_tag1
+  @scenario_tag2
+  @scenario_tag3
+  Scenario: minimalistic
+    Given the minimalism
+
+  @so_tag1
+  @so_tag2
+  @so_tag3
+  Scenario Outline: minimalistic outline
+    Given the <what>
+
+    @ex_tag1
+    @ex_tag2
+    @ex_tag3
+    Examples:
+      | what       |
+      | minimalism |
+
+    @ex_tag4
+    @ex_tag5
+    @ex_tag6
+    Examples:
+      | what            |
+      | more minimalism |
+
+  @comment_tag1
+  Scenario: comments
+    Given a comment
+
+  @comment_tag#2
+  Scenario: hash in tags
+    Given a comment is preceded by a space
+
+  @rule_tag
+  Rule:
+
+    @joined_tag3
+    @joined_tag4
+    Scenario: joined tags
+      Given the @delimits tags
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@feature_tag1
+@feature_tag2
+@feature_tag3
+Feature: Minimal Scenario Outline
+
     @scenario_tag1
     @scenario_tag2
     @scenario_tag3
@@ -2346,47 +3147,47 @@ options: {
 @feature_tag3
 Feature: Minimal Scenario Outline
 
-    @scenario_tag1
-    @scenario_tag2
-    @scenario_tag3
-    Scenario: minimalistic
-        Given the minimalism
+  @scenario_tag1
+  @scenario_tag2
+  @scenario_tag3
+  Scenario: minimalistic
+    Given the minimalism
 
-    @so_tag1
-    @so_tag2
-    @so_tag3
-    Scenario Outline: minimalistic outline
-        Given the <what>
+  @so_tag1
+  @so_tag2
+  @so_tag3
+  Scenario Outline: minimalistic outline
+    Given the <what>
 
-        @ex_tag1
-        @ex_tag2
-        @ex_tag3
-        Examples:
-            | what       |
-            | minimalism |
+    @ex_tag1
+    @ex_tag2
+    @ex_tag3
+    Examples:
+      | what       |
+      | minimalism |
 
-        @ex_tag4
-        @ex_tag5
-        @ex_tag6
-        Examples:
-            | what            |
-            | more minimalism |
+    @ex_tag4
+    @ex_tag5
+    @ex_tag6
+    Examples:
+      | what            |
+      | more minimalism |
 
-    @comment_tag1
-    Scenario: comments
-        Given a comment
+  @comment_tag1
+  Scenario: comments
+    Given a comment
 
-    @comment_tag#2
-    Scenario: hash in tags
-        Given a comment is preceded by a space
+  @comment_tag#2
+  Scenario: hash in tags
+    Given a comment is preceded by a space
 
-    @rule_tag
-    Rule:
+  @rule_tag
+  Rule:
 
-        @joined_tag3
-        @joined_tag4
-        Scenario: joined tags
-            Given the @delimits tags
+    @joined_tag3
+    @joined_tag4
+    Scenario: joined tags
+      Given the @delimits tags
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -4102,6 +4903,1614 @@ Feature: Long feature file
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Long feature file
+  This is a long feature file
+
+  Scenario: scenario 01
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 02
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 03
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 04
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 05
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 06
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 07
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 08
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 09
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 10
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 11
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 12
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 13
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 14
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 15
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 16
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 17
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 18
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 19
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 20
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 21
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 22
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 23
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 24
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 25
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 26
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 27
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 28
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 29
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 30
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 31
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 32
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 33
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 34
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 35
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 36
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 37
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 38
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 39
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 40
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 41
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 42
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 43
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 44
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 45
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 46
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 47
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 48
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 49
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 50
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 51
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 52
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 53
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 54
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 55
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 56
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 57
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 58
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 59
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 60
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 61
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 62
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 63
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 64
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 65
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 66
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 67
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 68
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 69
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 70
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 71
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 72
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 73
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 74
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 75
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 76
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 77
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 78
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 79
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 80
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 81
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 82
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 83
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 84
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 85
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 86
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 87
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 88
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 89
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 90
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 91
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 92
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 93
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 94
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 95
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 96
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 97
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 98
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 99
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 100
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Long feature file
     This is a long feature file
 
     Scenario: scenario 01
@@ -5710,1607 +8119,1607 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Long feature file
-    This is a long feature file
-
-    Scenario: scenario 01
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 02
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 03
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 04
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 05
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 06
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 07
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 08
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 09
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 10
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 11
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 12
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 13
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 14
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 15
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 16
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 17
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 18
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 19
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 20
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 21
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 22
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 23
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 24
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 25
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 26
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 27
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 28
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 29
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 30
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 31
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 32
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 33
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 34
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 35
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 36
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 37
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 38
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 39
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 40
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 41
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 42
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 43
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 44
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 45
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 46
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 47
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 48
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 49
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 50
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 51
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 52
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 53
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 54
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 55
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 56
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 57
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 58
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 59
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 60
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 61
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 62
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 63
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 64
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 65
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 66
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 67
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 68
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 69
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 70
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 71
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 72
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 73
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 74
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 75
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 76
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 77
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 78
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 79
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 80
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 81
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 82
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 83
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 84
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 85
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 86
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 87
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 88
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 89
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 90
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 91
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 92
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 93
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 94
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 95
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 96
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 97
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 98
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 99
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
-
-    Scenario: scenario 100
-        Given a simple data table
-            | foo | bar |
-            | boz | boo |
-        And a data table with a single cell
-            | foo |
-        And a data table with different fromatting
-            | foo | bar | boz |
-        And a data table with an empty cell
-            | foo |  | boz |
-        And a data table with comments and newlines inside
-            | foo  | bar  |
-            | boz  | boo  |
-            # this is a comment
-            | boz2 | boo2 |
+  This is a long feature file
+
+  Scenario: scenario 01
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 02
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 03
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 04
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 05
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 06
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 07
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 08
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 09
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 10
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 11
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 12
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 13
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 14
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 15
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 16
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 17
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 18
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 19
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 20
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 21
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 22
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 23
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 24
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 25
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 26
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 27
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 28
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 29
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 30
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 31
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 32
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 33
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 34
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 35
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 36
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 37
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 38
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 39
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 40
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 41
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 42
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 43
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 44
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 45
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 46
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 47
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 48
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 49
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 50
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 51
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 52
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 53
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 54
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 55
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 56
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 57
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 58
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 59
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 60
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 61
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 62
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 63
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 64
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 65
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 66
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 67
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 68
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 69
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 70
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 71
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 72
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 73
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 74
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 75
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 76
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 77
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 78
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 79
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 80
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 81
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 82
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 83
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 84
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 85
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 86
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 87
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 88
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 89
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 90
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 91
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 92
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 93
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 94
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 95
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 96
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 97
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 98
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 99
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
+
+  Scenario: scenario 100
+    Given a simple data table
+      | foo | bar |
+      | boz | boo |
+    And a data table with a single cell
+      | foo |
+    And a data table with different fromatting
+      | foo | bar | boz |
+    And a data table with an empty cell
+      | foo |  | boz |
+    And a data table with comments and newlines inside
+      | foo  | bar  |
+      | boz  | boo  |
+      # this is a comment
+      | boz2 | boo2 |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;

--- a/tests/plugin/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/plugin/__snapshots__/jsfmt.spec.mjs.snap
@@ -16,6 +16,20 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Example with multiple Background Steps
 
+  Background:
+    Given the user is on the homepage
+    And the user has the language "en" selected in the user settings
+
+  Scenario: example Scenario
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Example with multiple Background Steps
+
     Background:
         Given the user is on the homepage
         And the user has the language "en" selected in the user settings
@@ -30,11 +44,11 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Example with multiple Background Steps
 
-    Background:
-        Given the user is on the homepage
-        And the user has the language "en" selected in the user settings
+  Background:
+    Given the user is on the homepage
+    And the user has the language "en" selected in the user settings
 
-    Scenario: example Scenario
+  Scenario: example Scenario
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,6 +74,25 @@ Feature: A comment before a "Given" should stay before the "Given".
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: A comment before a "Given" should stay before the "Given".
+  The blankline should be before the comment and not between the comment and the
+  "Given".
+
+  Scenario:
+    Given I have a feature file
+    When I run the feature file
+    Then I should see the output
+
+    # this comment should stay just before the second given
+    Given I have another feature file
+    When I run the feature file
+    Then I should see the output
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: A comment before a "Given" should stay before the "Given".
     The blankline should be before the comment and not between the comment and
     the "Given".
 
@@ -79,20 +112,20 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: A comment before a "Given" should stay before the "Given".
-    The blankline should be before the comment and not between the comment and
-    the "Given".
+  The blankline should be before the comment and not between the comment and the
+  "Given".
 
-    Scenario:
-        Given I have a feature file
+  Scenario:
+    Given I have a feature file
 
-        When I run the feature file
-        Then I should see the output
+    When I run the feature file
+    Then I should see the output
 
-        # this comment should stay just before the second given
-        Given I have another feature file
+    # this comment should stay just before the second given
+    Given I have another feature file
 
-        When I run the feature file
-        Then I should see the output
+    When I run the feature file
+    Then I should see the output
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -115,6 +148,21 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: accountability
 
+  Scenario: Scenario Outline name
+    Given context
+    Then table node with a comment:
+      | amountForPro       | 0  |
+      # a comment in between
+      | collectedFeeAmount | 95 |
+    Then result
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: accountability
+
     Scenario: Scenario Outline name
         Given context
         Then table node with a comment:
@@ -130,13 +178,13 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: accountability
 
-    Scenario: Scenario Outline name
-        Given context
-        Then table node with a comment:
-            | amountForPro       | 0  |
-            # a comment in between
-            | collectedFeeAmount | 95 |
-        Then result
+  Scenario: Scenario Outline name
+    Given context
+    Then table node with a comment:
+      | amountForPro       | 0  |
+      # a comment in between
+      | collectedFeeAmount | 95 |
+    Then result
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -157,6 +205,19 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: A data table with PHP Fully Qualified Classnames
 
+  Scenario:
+    When I have a data table
+      | entityClassName | id |
+      | App\\Entity\\Cart | 4  |
+      | App\\Entity\\Cart | 5  |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: A data table with PHP Fully Qualified Classnames
+
     Scenario:
         When I have a data table
             | entityClassName | id |
@@ -170,11 +231,11 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: A data table with PHP Fully Qualified Classnames
 
-    Scenario:
-        When I have a data table
-            | entityClassName | id |
-            | App\\Entity\\Cart | 4  |
-            | App\\Entity\\Cart | 5  |
+  Scenario:
+    When I have a data table
+      | entityClassName | id |
+      | App\\Entity\\Cart | 4  |
+      | App\\Entity\\Cart | 5  |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -240,6 +301,60 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Test different embed
 
+  Scenario: XML
+    When I receive the following feed from the bank:
+      """xml
+      <feed>
+        <account number="123456789">
+          <entry>
+            <type>credit</type>
+            <amount>1000</amount>
+            <label>My company salary</label>
+          </entry>
+        </account>
+      </feed>
+      """
+
+  Scenario: JSON
+    When I receive the following feed from the bank:
+      """json
+      { "account": "1234", "amount": 1000 }
+      """
+
+  Scenario: JSON if no language is specified (default fallback)
+    When I receive the following feed from the bank:
+      """
+      { "account": "1234", "amount": 1000 }
+      """
+
+  Scenario: GraphQL
+    When I make the following query to the API:
+      """graphql
+      union Transaction = CreditTransaction | DebitTransaction
+
+      query AccountBalance($accountNumber: String!) {
+        account(accountNumber: $accountNumber) {
+          balance
+          transactions {
+            amount
+          }
+        }
+      }
+      """
+
+  Scenario: Unknown
+    When I make the following query to the API:
+      """unknown-language
+      this language is not known from prettier
+      """
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Test different embed
+
     Scenario: XML
         When I receive the following feed from the bank:
             """xml
@@ -294,52 +409,52 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Test different embed
 
-    Scenario: XML
-        When I receive the following feed from the bank:
-            """xml
-            <feed>
-                <account number="123456789">
-                    <entry>
-                        <type>credit</type>
-                        <amount>1000</amount>
-                        <label>My company salary</label>
-                    </entry>
-                </account>
-            </feed>
-            """
+  Scenario: XML
+    When I receive the following feed from the bank:
+      """xml
+      <feed>
+        <account number="123456789">
+          <entry>
+            <type>credit</type>
+            <amount>1000</amount>
+            <label>My company salary</label>
+          </entry>
+        </account>
+      </feed>
+      """
 
-    Scenario: JSON
-        When I receive the following feed from the bank:
-            """json
-            { "account": "1234", "amount": 1000 }
-            """
+  Scenario: JSON
+    When I receive the following feed from the bank:
+      """json
+      { "account": "1234", "amount": 1000 }
+      """
 
-    Scenario: JSON if no language is specified (default fallback)
-        When I receive the following feed from the bank:
-            """
-            { "account": "1234", "amount": 1000 }
-            """
+  Scenario: JSON if no language is specified (default fallback)
+    When I receive the following feed from the bank:
+      """
+      { "account": "1234", "amount": 1000 }
+      """
 
-    Scenario: GraphQL
-        When I make the following query to the API:
-            """graphql
-            union Transaction = CreditTransaction | DebitTransaction
+  Scenario: GraphQL
+    When I make the following query to the API:
+      """graphql
+      union Transaction = CreditTransaction | DebitTransaction
 
-            query AccountBalance($accountNumber: String!) {
-                account(accountNumber: $accountNumber) {
-                    balance
-                    transactions {
-                        amount
-                    }
-                }
-            }
-            """
+      query AccountBalance($accountNumber: String!) {
+        account(accountNumber: $accountNumber) {
+          balance
+          transactions {
+            amount
+          }
+        }
+      }
+      """
 
-    Scenario: Unknown
-        When I make the following query to the API:
-            """unknown-language
-            this language is not known from prettier
-            """
+  Scenario: Unknown
+    When I make the following query to the API:
+      """unknown-language
+      this language is not known from prettier
+      """
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -381,6 +496,40 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: complex docstring with JSON in it
 
+  Scenario:
+    Given a docstring with
+      """
+      1
+      "
+      2
+      \\"
+      3
+      \\"\\"\\"
+      4
+      """
+
+    Given I have a complex docstring
+      """
+      A docstring that is not JSON
+      =======================================
+
+      but will include some somewhere
+      -----------------------------------------------------
+
+       [WARNING] Some warning
+
+                 {"error":"NOT AUTHENTICATED","comment":"authentication refused"}
+
+       [OK] Declarations complete.
+      """
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: complex docstring with JSON in it
+
     Scenario:
         Given a docstring with
             """
@@ -415,32 +564,32 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: complex docstring with JSON in it
 
-    Scenario:
-        Given a docstring with
-            """
-            1
-            "
-            2
-            \\"
-            3
-            \\"\\"\\"
-            4
-            """
+  Scenario:
+    Given a docstring with
+      """
+      1
+      "
+      2
+      \\"
+      3
+      \\"\\"\\"
+      4
+      """
 
-        Given I have a complex docstring
-            """
-            A docstring that is not JSON
-            =======================================
+    Given I have a complex docstring
+      """
+      A docstring that is not JSON
+      =======================================
 
-            but will include some somewhere
-            -----------------------------------------------------
+      but will include some somewhere
+      -----------------------------------------------------
 
-             [WARNING] Some warning
+       [WARNING] Some warning
 
-                       {"error":"NOT AUTHENTICATED","comment":"authentication refused"}
+                 {"error":"NOT AUTHENTICATED","comment":"authentication refused"}
 
-             [OK] Declarations complete.
-            """
+       [OK] Declarations complete.
+      """
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -496,6 +645,53 @@ options: {}
 @accountability
 @accountability-json
 Feature: accountability
+  accounts should always be good
+
+  Scenario Outline: Scenario Outline name
+    Given I have <number> cukes in my belly
+    When I wait <hour> hour
+    Then my belly should growl
+
+    Examples:
+      | number | hour                      |
+      | 1      | the first hour of the day |
+      | 2      | 2                         |
+
+  @truncateTables
+  Scenario: Check accountability
+    The scenario definition for "Check accountability"
+
+    # Insert fixtures
+    Given the following fixtures files are loaded:
+      | 10.contracts.yml |
+      | 20.wallet.yml    |
+      | 30.tax.yml       |
+
+    Given I inject the header "authorization" with value 'Bearer some-token'
+
+    And I inject the header "accept" with value "application/json"
+
+    Given I create an order
+    Then the response status code should be 200
+    When I pay the latest order
+    And I refund the last payment and transaction list with transactions:
+      """
+      [
+        {
+          "name": "card",
+          "credit": 5000
+        }
+      ]
+      """
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@accountability
+@accountability-json
+Feature: accountability
     accounts should always be good
 
     Scenario Outline: Scenario Outline name
@@ -543,45 +739,45 @@ options: {
 @accountability
 @accountability-json
 Feature: accountability
-    accounts should always be good
+  accounts should always be good
 
-    Scenario Outline: Scenario Outline name
-        Given I have <number> cukes in my belly
+  Scenario Outline: Scenario Outline name
+    Given I have <number> cukes in my belly
 
-        When I wait <hour> hour
-        Then my belly should growl
+    When I wait <hour> hour
+    Then my belly should growl
 
-        Examples:
-            | number | hour                      |
-            | 1      | the first hour of the day |
-            | 2      | 2                         |
+    Examples:
+      | number | hour                      |
+      | 1      | the first hour of the day |
+      | 2      | 2                         |
 
-    @truncateTables
-    Scenario: Check accountability
-        The scenario definition for "Check accountability"
+  @truncateTables
+  Scenario: Check accountability
+    The scenario definition for "Check accountability"
 
-        # Insert fixtures
-        Given the following fixtures files are loaded:
-            | 10.contracts.yml |
-            | 20.wallet.yml    |
-            | 30.tax.yml       |
+    # Insert fixtures
+    Given the following fixtures files are loaded:
+      | 10.contracts.yml |
+      | 20.wallet.yml    |
+      | 30.tax.yml       |
 
-        Given I inject the header "authorization" with value 'Bearer some-token'
-        And I inject the header "accept" with value "application/json"
+    Given I inject the header "authorization" with value 'Bearer some-token'
+    And I inject the header "accept" with value "application/json"
 
-        Given I create an order
-        Then the response status code should be 200
+    Given I create an order
+    Then the response status code should be 200
 
-        When I pay the latest order
-        And I refund the last payment and transaction list with transactions:
-            """
-            [
-                {
-                    "name": "card",
-                    "credit": 5000
-                }
-            ]
-            """
+    When I pay the latest order
+    And I refund the last payment and transaction list with transactions:
+      """
+      [
+        {
+          "name": "card",
+          "credit": 5000
+        }
+      ]
+      """
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -600,6 +796,18 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: some feature
 
+  Scenario: Insert fixtures
+    # add OAuth token
+    Given something
+
+# saleStartDate is on summer time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: some feature
+
     Scenario: Insert fixtures
         # add OAuth token
         Given something
@@ -612,9 +820,9 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: some feature
 
-    Scenario: Insert fixtures
-        # add OAuth token
-        Given something
+  Scenario: Insert fixtures
+    # add OAuth token
+    Given something
 
 # saleStartDate is on summer time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -637,6 +845,20 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: some feature
 
+  Scenario: Insert fixtures
+    # add OAuth token
+    Given something
+
+# Then the response status code should be 403
+# And the JSON nodes should be equal to:
+#     | hydra:description | Some error did happened |
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: some feature
+
     Scenario: Insert fixtures
         # add OAuth token
         Given something
@@ -651,9 +873,9 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: some feature
 
-    Scenario: Insert fixtures
-        # add OAuth token
-        Given something
+  Scenario: Insert fixtures
+    # add OAuth token
+    Given something
 
 # Then the response status code should be 403
 # And the JSON nodes should be equal to:
@@ -677,6 +899,19 @@ options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: f
 
+  Scenario: s
+    When context
+    # comment 1
+    # comment 2
+    Then result
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: f
+
     Scenario: s
         When context
         # comment 1
@@ -690,11 +925,11 @@ options: {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: f
 
-    Scenario: s
-        When context
-        # comment 1
-        # comment 2
-        Then result
+  Scenario: s
+    When context
+    # comment 1
+    # comment 2
+    Then result
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -717,6 +952,19 @@ options: {}
 # feature comment
 Feature: coucou
 
+  # scenario comment
+  Scenario: Scenario name
+    # step comment
+    Given a step
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# feature comment
+Feature: coucou
+
     # scenario comment
     Scenario: Scenario name
         # step comment
@@ -730,10 +978,10 @@ options: {
 # feature comment
 Feature: coucou
 
-    # scenario comment
-    Scenario: Scenario name
-        # step comment
-        Given a step
+  # scenario comment
+  Scenario: Scenario name
+    # step comment
+    Given a step
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -768,6 +1016,33 @@ Feature: Escaped pipes
 options: {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Escaped pipes
+  The \\-character will be considered as an escape in table cell
+  iff it is followed by a |-character, a \\-character or an n.
+
+  Scenario: They are the future
+    Given a huge table with escaped characters
+      | \\n       |
+      | \\\\n     |
+      | \\\\\\n     |
+      | \\\\\\\\n   |
+      | \\\\\\\\\\n   |
+      | \\\\\\\\\\\\n |
+      | \\|      |
+      | \\\\\\|    |
+      | \\       |
+      | a\\b     |
+      | a\\b     |
+      | a\\\\\\b   |
+      | a\\\\\\b   |
+      | a\\      |
+      | \\a      |
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: Escaped pipes
     The \\-character will be considered as an escape in table cell
     iff it is followed by a |-character, a \\-character or an n.
 
@@ -795,26 +1070,26 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: Escaped pipes
-    The \\-character will be considered as an escape in table cell
-    iff it is followed by a |-character, a \\-character or an n.
+  The \\-character will be considered as an escape in table cell
+  iff it is followed by a |-character, a \\-character or an n.
 
-    Scenario: They are the future
-        Given a huge table with escaped characters
-            | \\n       |
-            | \\\\n     |
-            | \\\\\\n     |
-            | \\\\\\\\n   |
-            | \\\\\\\\\\n   |
-            | \\\\\\\\\\\\n |
-            | \\|      |
-            | \\\\\\|    |
-            | \\       |
-            | a\\b     |
-            | a\\b     |
-            | a\\\\\\b   |
-            | a\\\\\\b   |
-            | a\\      |
-            | \\a      |
+  Scenario: They are the future
+    Given a huge table with escaped characters
+      | \\n       |
+      | \\\\n     |
+      | \\\\\\n     |
+      | \\\\\\\\n   |
+      | \\\\\\\\\\n   |
+      | \\\\\\\\\\\\n |
+      | \\|      |
+      | \\\\\\|    |
+      | \\       |
+      | a\\b     |
+      | a\\b     |
+      | a\\\\\\b   |
+      | a\\\\\\b   |
+      | a\\      |
+      | \\a      |
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
@@ -833,6 +1108,59 @@ Feature: A very long feature name should be broken after printWidth  Lorem ipsum
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 options: {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: A very long feature name should be broken after printWidth  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vestibulum eu urna ac placerat. Nulla vehicula id mi vitae tristique. Donec imperdiet tincidunt tellus, ac imperdiet metus venenatis sed. Cras quis est tempor justo luctus rutrum. Praesent accumsan, leo in commodo eleifend, lorem ex accumsan dui, nec rutrum lorem leo vitae neque. Fusce nec magna in arcu imperdiet tincidunt. In auctor velit ante, et interdum tellus commodo a. Donec in euismod tellus. Donec in nibh sit amet magna sagittis mollis accumsan ac felis. Proin suscipit turpis id ornare maximus.
+  Phasellus ultrices mattis erat vitae consectetur. Mauris nec volutpat tortor.
+  Duis maximus ipsum ac felis ultricies scelerisque. Sed vehicula ex vitae
+  iaculis rhoncus. Etiam tortor quam, scelerisque non interdum imperdiet,
+  euismod id dui. Etiam tristique fringilla bibendum. Vivamus efficitur elit sed
+  augue lacinia blandit. In bibendum eget lorem quis pretium. Quisque sapien
+  est, feugiat ornare dictum nec, rutrum sed quam. Vestibulum ante ipsum primis
+  in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque
+  tincidunt vehicula leo in tristique. Sed ut gravida urna, pulvinar aliquam
+  eros. Suspendisse sed leo sed mi consequat fringilla. Pellentesque habitant
+  morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+
+  Scenario: Morbi ligula lorem, mollis quis porttitor non, hendrerit in purus. Aenean a dui malesuada, euismod lacus sit amet, mollis ante. Vestibulum purus diam, malesuada a pulvinar a, ullamcorper nec odio. Nam volutpat faucibus pulvinar. Mauris maximus enim nec quam rhoncus, at semper nunc sagittis. In finibus, libero quis tristique viverra, magna erat mattis tortor, eu accumsan felis risus vitae diam. Praesent eleifend hendrerit tempor. Quisque nec posuere justo.
+    Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
+    erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo
+    vehicula sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in
+    ipsum in quam viverra convallis. Sed et tellus nec neque luctus bibendum ac
+    et augue. Nunc tincidunt interdum ex in mollis. Donec faucibus interdum
+    massa, vel congue lectus molestie at. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Sed fringilla justo vitae ultricies pretium.
+    Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius natoque
+    penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed
+    pretium eget leo ac luctus. Etiam tristique commodo libero, at egestas lacus
+    pharetra id. Curabitur nec sapien id mauris viverra tempus.
+    Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis erat
+    ut, egestas sem. Mauris tristique massa velit, id feugiat justo vehicula sodales.
+    Morbi mattis ipsum vel leo varius venenatis. Etiam in ipsum in quam viverra convallis.
+    Sed et tellus nec neque luctus bibendum ac et augue. Nunc tincidunt interdum
+    ex in mollis. Donec faucibus interdum massa, vel congue lectus molestie at. Lorem
+    ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla justo vitae
+    ultricies pretium. Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius
+    natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed
+    pretium eget leo ac luctus. Etiam tristique commodo libero, at egestas lacus
+    pharetra id. Curabitur nec sapien id mauris viverra tempus.
+    Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
+    erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo
+    vehicula sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in
+    ipsum in quam viverra convallis. Sed et tellus nec neque luctus bibendum ac
+    et augue. Nunc tincidunt interdum ex in mollis. Donec faucibus interdum
+    massa, vel congue lectus molestie at. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Sed fringilla justo vitae ultricies pretium.
+    Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius natoque
+    penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed
+    pretium eget leo ac luctus. Etiam tristique commodo libero, at egestas lacus
+    pharetra id. Curabitur nec sapien id mauris viverra tempus.
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: A very long feature name should be broken after printWidth  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vestibulum eu urna ac placerat. Nulla vehicula id mi vitae tristique. Donec imperdiet tincidunt tellus, ac imperdiet metus venenatis sed. Cras quis est tempor justo luctus rutrum. Praesent accumsan, leo in commodo eleifend, lorem ex accumsan dui, nec rutrum lorem leo vitae neque. Fusce nec magna in arcu imperdiet tincidunt. In auctor velit ante, et interdum tellus commodo a. Donec in euismod tellus. Donec in nibh sit amet magna sagittis mollis accumsan ac felis. Proin suscipit turpis id ornare maximus.
     Phasellus ultrices mattis erat vitae consectetur. Mauris nec volutpat
@@ -892,54 +1220,50 @@ options: {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Feature: A very long feature name should be broken after printWidth  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vestibulum eu urna ac placerat. Nulla vehicula id mi vitae tristique. Donec imperdiet tincidunt tellus, ac imperdiet metus venenatis sed. Cras quis est tempor justo luctus rutrum. Praesent accumsan, leo in commodo eleifend, lorem ex accumsan dui, nec rutrum lorem leo vitae neque. Fusce nec magna in arcu imperdiet tincidunt. In auctor velit ante, et interdum tellus commodo a. Donec in euismod tellus. Donec in nibh sit amet magna sagittis mollis accumsan ac felis. Proin suscipit turpis id ornare maximus.
-    Phasellus ultrices mattis erat vitae consectetur. Mauris nec volutpat
-    tortor. Duis maximus ipsum ac felis ultricies scelerisque. Sed vehicula ex
-    vitae iaculis rhoncus. Etiam tortor quam, scelerisque non interdum
-    imperdiet, euismod id dui. Etiam tristique fringilla bibendum. Vivamus
-    efficitur elit sed augue lacinia blandit. In bibendum eget lorem quis
-    pretium. Quisque sapien est, feugiat ornare dictum nec, rutrum sed quam.
-    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
-    cubilia curae; Pellentesque tincidunt vehicula leo in tristique. Sed ut
-    gravida urna, pulvinar aliquam eros. Suspendisse sed leo sed mi consequat
-    fringilla. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
+  Phasellus ultrices mattis erat vitae consectetur. Mauris nec volutpat tortor.
+  Duis maximus ipsum ac felis ultricies scelerisque. Sed vehicula ex vitae
+  iaculis rhoncus. Etiam tortor quam, scelerisque non interdum imperdiet,
+  euismod id dui. Etiam tristique fringilla bibendum. Vivamus efficitur elit sed
+  augue lacinia blandit. In bibendum eget lorem quis pretium. Quisque sapien
+  est, feugiat ornare dictum nec, rutrum sed quam. Vestibulum ante ipsum primis
+  in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque
+  tincidunt vehicula leo in tristique. Sed ut gravida urna, pulvinar aliquam
+  eros. Suspendisse sed leo sed mi consequat fringilla. Pellentesque habitant
+  morbi tristique senectus et netus et malesuada fames ac turpis egestas.
 
-    Scenario: Morbi ligula lorem, mollis quis porttitor non, hendrerit in purus. Aenean a dui malesuada, euismod lacus sit amet, mollis ante. Vestibulum purus diam, malesuada a pulvinar a, ullamcorper nec odio. Nam volutpat faucibus pulvinar. Mauris maximus enim nec quam rhoncus, at semper nunc sagittis. In finibus, libero quis tristique viverra, magna erat mattis tortor, eu accumsan felis risus vitae diam. Praesent eleifend hendrerit tempor. Quisque nec posuere justo.
-        Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
-        erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo
-        vehicula sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in
-        ipsum in quam viverra convallis. Sed et tellus nec neque luctus bibendum
-        ac et augue. Nunc tincidunt interdum ex in mollis. Donec faucibus
-        interdum massa, vel congue lectus molestie at. Lorem ipsum dolor sit
-        amet, consectetur adipiscing elit. Sed fringilla justo vitae ultricies
-        pretium. Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius
-        natoque penatibus et magnis dis parturient montes, nascetur ridiculus
-        mus. Sed pretium eget leo ac luctus. Etiam tristique commodo libero, at
-        egestas lacus pharetra id. Curabitur nec sapien id mauris viverra
-        tempus.
-        Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
-        erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo vehicula
-        sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in ipsum in quam
-        viverra convallis. Sed et tellus nec neque luctus bibendum ac et augue. Nunc
-        tincidunt interdum ex in mollis. Donec faucibus interdum massa, vel congue
-        lectus molestie at. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        Sed fringilla justo vitae ultricies pretium. Nam pulvinar sem risus, a sagittis
-        mi fermentum ac. Orci varius natoque penatibus et magnis dis parturient montes,
-        nascetur ridiculus mus. Sed pretium eget leo ac luctus. Etiam tristique commodo
-        libero, at egestas lacus pharetra id. Curabitur nec sapien id mauris viverra
-        tempus.
-        Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
-        erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo
-        vehicula sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in
-        ipsum in quam viverra convallis. Sed et tellus nec neque luctus bibendum
-        ac et augue. Nunc tincidunt interdum ex in mollis. Donec faucibus
-        interdum massa, vel congue lectus molestie at. Lorem ipsum dolor sit
-        amet, consectetur adipiscing elit. Sed fringilla justo vitae ultricies
-        pretium. Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius
-        natoque penatibus et magnis dis parturient montes, nascetur ridiculus
-        mus. Sed pretium eget leo ac luctus. Etiam tristique commodo libero, at
-        egestas lacus pharetra id. Curabitur nec sapien id mauris viverra
-        tempus.
+  Scenario: Morbi ligula lorem, mollis quis porttitor non, hendrerit in purus. Aenean a dui malesuada, euismod lacus sit amet, mollis ante. Vestibulum purus diam, malesuada a pulvinar a, ullamcorper nec odio. Nam volutpat faucibus pulvinar. Mauris maximus enim nec quam rhoncus, at semper nunc sagittis. In finibus, libero quis tristique viverra, magna erat mattis tortor, eu accumsan felis risus vitae diam. Praesent eleifend hendrerit tempor. Quisque nec posuere justo.
+    Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
+    erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo
+    vehicula sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in
+    ipsum in quam viverra convallis. Sed et tellus nec neque luctus bibendum ac
+    et augue. Nunc tincidunt interdum ex in mollis. Donec faucibus interdum
+    massa, vel congue lectus molestie at. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Sed fringilla justo vitae ultricies pretium.
+    Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius natoque
+    penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed
+    pretium eget leo ac luctus. Etiam tristique commodo libero, at egestas lacus
+    pharetra id. Curabitur nec sapien id mauris viverra tempus.
+    Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis erat
+    ut, egestas sem. Mauris tristique massa velit, id feugiat justo vehicula sodales.
+    Morbi mattis ipsum vel leo varius venenatis. Etiam in ipsum in quam viverra convallis.
+    Sed et tellus nec neque luctus bibendum ac et augue. Nunc tincidunt interdum
+    ex in mollis. Donec faucibus interdum massa, vel congue lectus molestie at. Lorem
+    ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla justo vitae
+    ultricies pretium. Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius
+    natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed
+    pretium eget leo ac luctus. Etiam tristique commodo libero, at egestas lacus
+    pharetra id. Curabitur nec sapien id mauris viverra tempus.
+    Maecenas ullamcorper porta sapien. Vestibulum id ex fermentum, convallis
+    erat ut, egestas sem. Mauris tristique massa velit, id feugiat justo
+    vehicula sodales. Morbi mattis ipsum vel leo varius venenatis. Etiam in
+    ipsum in quam viverra convallis. Sed et tellus nec neque luctus bibendum ac
+    et augue. Nunc tincidunt interdum ex in mollis. Donec faucibus interdum
+    massa, vel congue lectus molestie at. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Sed fringilla justo vitae ultricies pretium.
+    Nam pulvinar sem risus, a sagittis mi fermentum ac. Orci varius natoque
+    penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed
+    pretium eget leo ac luctus. Etiam tristique commodo libero, at egestas lacus
+    pharetra id. Curabitur nec sapien id mauris viverra tempus.
 
 
 

--- a/tests_config/run_spec.mjs
+++ b/tests_config/run_spec.mjs
@@ -77,6 +77,9 @@ function run_spec(importMeta, options) {
         };
 
         const defaultOutput = await getOutput({});
+        const overrideTabWidthOutput = await getOutput({
+          tabWidth: 4,
+        });
         const outputWithNewline = await getOutput({
           forceNewlineBetweenStepBlocks: true,
         });
@@ -88,6 +91,7 @@ function run_spec(importMeta, options) {
               lineSeparator +
               source +
               defaultOutput.snapshot +
+              overrideTabWidthOutput.snapshot +
               outputWithNewline.snapshot +
               lastLineSeparator
           )


### PR DESCRIPTION
According to the cucumber.io [Gherkin Reference](https://cucumber.io/docs/gherkin/reference/):

> Either spaces or tabs may be used for indentation. The recommended **indentation level is two spaces**.

Set this to the default value of prettier plugin too.

This will be a breaking change as it will change all tests for everybody.

Fixes #28 