### PR TITLE
Fix package.json warning

### DIFF
--- a/build/clean-dist.mjs
+++ b/build/clean-dist.mjs
@@ -1,0 +1,3 @@
+import fs from 'node:fs';
+
+await fs.promises.rm('dist/', { recursive: true, force: true });

--- a/package.json
+++ b/package.json
@@ -5,15 +5,20 @@
   "description": "This prettier plugin format your gherkin (`.feature` files) documents.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mapado/prettier-plugin-gherkin.git"
+    "url": "git+https://github.com/mapado/prettier-plugin-gherkin.git"
   },
   "bugs": {
     "url": "https://github.com/mapado/prettier-plugin-gherkin/issues"
   },
   "homepage": "https://github.com/mapado/prettier-plugin-gherkin",
-  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc",
+    "build": "node build/clean-dist.mjs && tsc",
     "lint": "tsc --noEmit",
     "example": "yarn build && prettier --plugin=dist/index.js tests/plugin/example.feature",
     "test": "yarn build && NODE_OPTIONS=--experimental-vm-modules jest",


### PR DESCRIPTION
See https://publint.dev/prettier-plugin-gherkin@3.1.1

- Drop "main" in package.json as prettier [do not support node > 14 anymore](https://prettier.io/blog/2023/07/05/3.0.0/#drop-support-for-nodejs-10-and-12-11830-by-fisker-13118-by-sosukesuzuki).
- clean dist before pushing package
- fix repository url