### PR TITLE
Fix blank lines inserted between consecutive comment lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stop inserting blank lines between consecutive `#` comment lines that lead a step requiring a leading hardline (e.g. with `forceNewlineBetweenStepBlocks: true`). Only the first comment in a contiguous block now prepends the hardline; subsequent comments are joined directly.
+
 ## [3.1.3] - 2025-10-13
 
 - Release package with npm trusted publisher only

--- a/src/index.ts
+++ b/src/index.ts
@@ -384,10 +384,17 @@ const gherkinAstPrinter: Printer<TypedGherkinNode<GherkinNode>> = {
     const previousNode = findPreviousNode(path, 6);
 
     // if the comment follows a `Given` step, then the comment should have a leading blank line
-    // but no blank line between the comment and the step
+    // but no blank line between the comment and the step.
+    // Only the first comment in a contiguous block prepends the hardline; subsequent
+    // comments rely on prettier's own join between leading own-line comments so that
+    // multi-line comment blocks do not get blank lines inserted between every line.
+    // @ts-expect-error comments are injected by prettier directly
+    const parentComments = stepNode?.comments ?? [];
+    const isFirstLeadingComment = parentComments.indexOf(node) <= 0;
     if (
       stepNode instanceof TypedStep &&
-      stepNeedsHardline(options, stepNode, previousNode)
+      stepNeedsHardline(options, stepNode, previousNode) &&
+      isFirstLeadingComment
     ) {
       return [printHardline(), node.text.trim()];
     }

--- a/tests/plugin/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/plugin/__snapshots__/jsfmt.spec.mjs.snap
@@ -992,6 +992,66 @@ Feature: f
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `;
 
+exports[`multiple_comments_line_before_step.feature 1`] = `
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: f
+    Scenario: s
+        When context
+        # comment 1
+        # comment 2
+        # comment 3
+        Given other context
+        Then result
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: f
+
+  Scenario: s
+    When context
+    # comment 1
+    # comment 2
+    # comment 3
+    Given other context
+    Then result
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "tabWidth": 4
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: f
+
+    Scenario: s
+        When context
+        # comment 1
+        # comment 2
+        # comment 3
+        Given other context
+        Then result
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+options: {
+ "forceNewlineBetweenStepBlocks": true
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature: f
+
+  Scenario: s
+    When context
+
+    # comment 1
+    # comment 2
+    # comment 3
+    Given other context
+    Then result
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`;
+
 exports[`simple-comment.feature 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 source

--- a/tests/plugin/multiple_comments_line_before_step.feature
+++ b/tests/plugin/multiple_comments_line_before_step.feature
@@ -1,0 +1,8 @@
+Feature: f
+    Scenario: s
+        When context
+        # comment 1
+        # comment 2
+        # comment 3
+        Given other context
+        Then result


### PR DESCRIPTION
Closes #32

## Summary

When a `#` comment block leads a step that requires a leading hardline (e.g. with `forceNewlineBetweenStepBlocks: true`, or when there was already a blank line before the previous step), every comment in the block currently has a hardline prepended individually. Prettier joins leading own-line comments with its own hardline, so the result is a blank line inserted between every consecutive comment line.

This change makes only the first comment in a contiguous leading block prepend the hardline; subsequent comments rely on prettier's join. Multi-line `#` comment blocks now stay together as a single block with at most one blank line in front of them.

A new fixture `tests/plugin/multiple_comments_line_before_step.feature` covers the case (a multi-line comment block leading a `Given` after a `When`, exercised against `forceNewlineBetweenStepBlocks: true`). The existing `multiple_comments_line.feature` snapshot is unchanged.

## Test plan

- [x] `yarn test` — 54/54 pass
- [x] Verified the new snapshot reflects the fix (single blank line before the comment block; no blank lines between comments) and that without the patch the same fixture produces a blank line between every comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)