### PR TITLE
Potential fix for code scanning alert no. 2: Double escaping or unescaping

### DIFF
--- a/src/GherkinAST/index.ts
+++ b/src/GherkinAST/index.ts
@@ -45,10 +45,10 @@ export function isWithLocation(node: unknown): node is GherkinNodeWithLocation {
 
 function reEscapeTableCell(str: string): string {
   const out = str
-    // espace all pipes that have been unescaped
-    .replaceAll('|', '\\|')
     // espace all backslashes that have been unescaped
-    .replace(/\\/g, '\\\\');
+    .replace(/\\/g, '\\\\')
+    // espace all pipes that have been unescaped
+    .replaceAll('|', '\\|');
 
   if (OPTIONS.escapeBackslashes) {
     return out;


### PR DESCRIPTION
Potential fix for [https://github.com/mapado/prettier-plugin-gherkin/security/code-scanning/2](https://github.com/mapado/prettier-plugin-gherkin/security/code-scanning/2)

To fix this without changing intended functionality, update `reEscapeTableCell` so backslashes are escaped **before** pipes. This ensures escape characters are handled first and prevents backslashes introduced by pipe-escaping from being escaped again.

In `src/GherkinAST/index.ts`, edit the replacement chain inside `reEscapeTableCell` (lines 47–51 region shown) as follows:

- First do `.replace(/\\/g, '\\\\')`
- Then do `.replaceAll('|', '\\|')`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
