### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mapado/prettier-plugin-gherkin/security/code-scanning/1](https://github.com/mapado/prettier-plugin-gherkin/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/node.js.yml` to restrict `GITHUB_TOKEN` privileges.  
Best fix without changing behavior: define workflow-level permissions right after the `on` block (before `jobs`) with `contents: read`. This grants only read access to repository contents for all jobs unless overridden, which is sufficient for `actions/checkout` and CI read operations in this file.

Concretely:
- **File**: `.github/workflows/node.js.yml`
- **Region**: between lines 10 and 12 (after trigger config, before `jobs:`)
- **Change**: insert:
  ```yml
  permissions:
    contents: read
  ```
No imports/dependencies/methods are needed for YAML workflow changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
